### PR TITLE
Unify groupId, artifactId and name of examples

### DIFF
--- a/javalin4/javalin-async-example/pom.xml
+++ b/javalin4/javalin-async-example/pom.xml
@@ -8,7 +8,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>io.javalin.samples.javalin4 javalin-async-example</name>
+    <name>Javalin 4 ${artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin4/javalin-cors-example/pom.xml
+++ b/javalin4/javalin-cors-example/pom.xml
@@ -3,12 +3,12 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.javalin</groupId>
+    <groupId>io.javalin.samples.javalin4</groupId>
     <artifactId>javalin-cors-example</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>io.javalin javalin-cors-example</name>
+    <name>Javalin 4 ${artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin4/javalin-email-example/pom.xml
+++ b/javalin4/javalin-email-example/pom.xml
@@ -4,9 +4,11 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.javalin</groupId>
-    <artifactId>javalin4-email-example</artifactId>
+    <groupId>io.javalin.samples.javalin4</groupId>
+    <artifactId>javalin-email-example</artifactId>
     <version>1.0-SNAPSHOT</version>
+
+    <name>Javalin 4 ${artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/javalin4/javalin-heroku-example/pom.xml
+++ b/javalin4/javalin-heroku-example/pom.xml
@@ -4,9 +4,11 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.javalin</groupId>
-    <artifactId>javalin4-heroku-example</artifactId>
+    <groupId>io.javalin.samples.javalin4</groupId>
+    <artifactId>javalin-heroku-example</artifactId>
     <version>1.0</version>
+
+    <name>Javalin 4 ${artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/javalin4/javalin-html-forms-example/pom.xml
+++ b/javalin4/javalin-html-forms-example/pom.xml
@@ -4,9 +4,11 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.javalin</groupId>
+    <groupId>io.javalin.samples.javalin4</groupId>
     <artifactId>javalin-html-forms-example</artifactId>
     <version>1.0-SNAPSHOT</version>
+
+    <name>Javalin 4 ${artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/javalin4/javalin-jetty-sessions-example/pom.xml
+++ b/javalin4/javalin-jetty-sessions-example/pom.xml
@@ -3,12 +3,12 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.javalin</groupId>
-    <artifactId>javalin4-jetty-sessions-example</artifactId>
+    <groupId>io.javalin.samples.javalin4</groupId>
+    <artifactId>javalin-jetty-sessions-example</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>io.javalin javalin-jetty-sessions-example</name>
+    <name>Javalin 4 ${artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin4/javalin-kotlin-example/pom.xml
+++ b/javalin4/javalin-kotlin-example/pom.xml
@@ -4,9 +4,11 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.javalin</groupId>
-    <artifactId>javalin4-kotlin-example</artifactId>
+    <groupId>io.javalin.samples.javalin4</groupId>
+    <artifactId>javalin-kotlin-example</artifactId>
     <version>1.0-SNAPSHOT</version>
+
+    <name>Javalin 4 ${artifactId}</name>
 
     <properties>
         <kotlin.version>1.5.20</kotlin.version>

--- a/javalin4/javalin-openapi-example/pom.xml
+++ b/javalin4/javalin-openapi-example/pom.xml
@@ -4,12 +4,12 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.javalin</groupId>
+    <groupId>io.javalin.samples.javalin4</groupId>
     <artifactId>javalin-openapi-example</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>io.javalin javalin-openapi-example</name>
+    <name>Javalin 4 ${artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin4/javalin-prometheus-example/pom.xml
+++ b/javalin4/javalin-prometheus-example/pom.xml
@@ -4,9 +4,11 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.javalin</groupId>
+    <groupId>io.javalin.samples.javalin4</groupId>
     <artifactId>javalin-prometheus-example</artifactId>
     <version>1.0-SNAPSHOT</version>
+
+    <name>Javalin 4 ${artifactId}</name>
 
     <properties>
         <kotlin.version>1.5.20</kotlin.version>

--- a/javalin4/javalin-realtime-collaboration-example/pom.xml
+++ b/javalin4/javalin-realtime-collaboration-example/pom.xml
@@ -3,12 +3,12 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.javalin</groupId>
-    <artifactId>javalin4-realtime-collaboration-example</artifactId>
+    <groupId>io.javalin.samples.javalin4</groupId>
+    <artifactId>javalin-realtime-collaboration-example</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>io.javalin javalin-realtime-collaboration-example</name>
+    <name>Javalin 4 ${artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin4/javalin-testing-example/pom.xml
+++ b/javalin4/javalin-testing-example/pom.xml
@@ -3,12 +3,12 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.javalin</groupId>
+    <groupId>io.javalin.samples.javalin4</groupId>
     <artifactId>javalin-testing-example</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>io.javalin javalin-testing-example</name>
+    <name>Javalin 4 ${artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin4/javalin-vuejs-example/pom.xml
+++ b/javalin4/javalin-vuejs-example/pom.xml
@@ -3,12 +3,12 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.javalin</groupId>
-    <artifactId>javalin4-vuejs-example</artifactId>
+    <groupId>io.javalin.samples.javalin4</groupId>
+    <artifactId>javalin-vuejs-example</artifactId>
     <version>1.0</version>
     <packaging>jar</packaging>
 
-    <name>io.javalin javalin-vuejs-example</name>
+    <name>Javalin 4 ${artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin4/javalin-website-example/pom.xml
+++ b/javalin4/javalin-website-example/pom.xml
@@ -4,9 +4,11 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.javalin</groupId>
+    <groupId>io.javalin.samples.javalin4</groupId>
     <artifactId>javalin-website-example</artifactId>
     <version>1.0</version>
+
+    <name>Javalin 4 ${artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/javalin4/javalin-websocket-example/pom.xml
+++ b/javalin4/javalin-websocket-example/pom.xml
@@ -4,9 +4,11 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.javalin</groupId>
-    <artifactId>javalin4-websocket-example</artifactId>
+    <groupId>io.javalin.samples.javalin4</groupId>
+    <artifactId>javalin-websocket-example</artifactId>
     <version>1.0</version>
+
+    <name>Javalin 4 ${artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/javalin4/javalinstagram/pom.xml
+++ b/javalin4/javalinstagram/pom.xml
@@ -8,7 +8,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>javalinstagram</name>
+    <name>Javalin 4 ${artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin4/javalinvue-example/javalinvue2-example/pom.xml
+++ b/javalin4/javalinvue-example/javalinvue2-example/pom.xml
@@ -8,7 +8,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>io.javalin.samples.javalin4 javalinvue2-example</name>
+    <name>Javalin 4 ${artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin4/javalinvue-example/javalinvue3-example/pom.xml
+++ b/javalin4/javalinvue-example/javalinvue3-example/pom.xml
@@ -8,7 +8,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>io.javalin.samples.javalin4 javalinvue3-example</name>
+    <name>Javalin 4 ${artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin4/pom.xml
+++ b/javalin4/pom.xml
@@ -7,6 +7,8 @@
     <version>1.0.0</version>
     <packaging>pom</packaging>
 
+    <name>Javalin 4 samples</name>
+
     <modules>
         <module>javalin-async-example</module>
         <!--<module>javalin-cors-example</module> checked-->

--- a/javalin5/javalin-async-example/pom.xml
+++ b/javalin5/javalin-async-example/pom.xml
@@ -3,12 +3,12 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.javalin</groupId>
+    <groupId>io.javalin.samples.javalin5</groupId>
     <artifactId>javalin-async-example</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>io.javalin javalin-async-example</name>
+    <name>Javalin 5 ${artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin5/javalin-auth-example/pom.xml
+++ b/javalin5/javalin-auth-example/pom.xml
@@ -3,12 +3,12 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.javalin</groupId>
+    <groupId>io.javalin.samples.javalin5</groupId>
     <artifactId>javalin-auth-example</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>org.example javalin-auth-example</name>
+    <name>Javalin 5 ${artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin5/javalin-cors-example/pom.xml
+++ b/javalin5/javalin-cors-example/pom.xml
@@ -3,12 +3,12 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.javalin</groupId>
+    <groupId>io.javalin.samples.javalin5</groupId>
     <artifactId>javalin-cors-example</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>io.javalin javalin-cors-example</name>
+    <name>Javalin 5 ${artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin5/javalin-email-example/pom.xml
+++ b/javalin5/javalin-email-example/pom.xml
@@ -4,9 +4,11 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.javalin</groupId>
+    <groupId>io.javalin.samples.javalin5</groupId>
     <artifactId>javalin-email-example</artifactId>
     <version>1.0-SNAPSHOT</version>
+
+    <name>Javalin 5 ${artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/javalin5/javalin-heroku-example/pom.xml
+++ b/javalin5/javalin-heroku-example/pom.xml
@@ -4,9 +4,11 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.javalin</groupId>
+    <groupId>io.javalin.samples.javalin5</groupId>
     <artifactId>javalin-heroku-example</artifactId>
     <version>1.0</version>
+
+    <name>Javalin 5 ${artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/javalin5/javalin-html-forms-example/pom.xml
+++ b/javalin5/javalin-html-forms-example/pom.xml
@@ -4,9 +4,11 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.javalin</groupId>
+    <groupId>io.javalin.samples.javalin5</groupId>
     <artifactId>javalin-html-forms-example</artifactId>
     <version>1.0-SNAPSHOT</version>
+
+    <name>Javalin 5 ${artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/javalin5/javalin-http2-example/pom.xml
+++ b/javalin5/javalin-http2-example/pom.xml
@@ -3,12 +3,12 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.javalin</groupId>
+    <groupId>io.javalin.samples.javalin5</groupId>
     <artifactId>javalin-http2-example</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>org.example javalin-http2-example</name>
+    <name>Javalin 5 ${artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin5/javalin-jetty-sessions-example/pom.xml
+++ b/javalin5/javalin-jetty-sessions-example/pom.xml
@@ -3,12 +3,12 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.javalin</groupId>
+    <groupId>io.javalin.samples.javalin5</groupId>
     <artifactId>javalin-jetty-sessions-example</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>io.javalin javalin-jetty-sessions-example</name>
+    <name>Javalin 5 ${artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin5/javalin-kotlin-example/pom.xml
+++ b/javalin5/javalin-kotlin-example/pom.xml
@@ -4,9 +4,11 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.javalin</groupId>
+    <groupId>io.javalin.samples.javalin5</groupId>
     <artifactId>javalin-kotlin-example</artifactId>
     <version>1.0-SNAPSHOT</version>
+
+    <name>Javalin 5 ${artifactId}</name>
 
     <properties>
         <kotlin.version>1.7.0</kotlin.version>

--- a/javalin5/javalin-modern-java-example/pom.xml
+++ b/javalin5/javalin-modern-java-example/pom.xml
@@ -2,14 +2,12 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.example</groupId>
+    <groupId>io.javalin.samples.javalin5</groupId>
     <artifactId>javalin-modern-java-example</artifactId>
     <version>1.0-SNAPSHOT</version>
-
     <packaging>jar</packaging>
 
-    <name>javalin-modern-java-example</name>
-    <url>http://maven.apache.org</url>
+    <name>Javalin 5 ${artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin5/javalin-openapi-example/pom.xml
+++ b/javalin5/javalin-openapi-example/pom.xml
@@ -4,12 +4,12 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.javalin</groupId>
+    <groupId>io.javalin.samples.javalin5</groupId>
     <artifactId>javalin-openapi-example</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>io.javalin javalin-openapi-example</name>
+    <name>Javalin 5 ${artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin5/javalin-prometheus-example/pom.xml
+++ b/javalin5/javalin-prometheus-example/pom.xml
@@ -4,9 +4,11 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.javalin</groupId>
+    <groupId>io.javalin.samples.javalin5</groupId>
     <artifactId>javalin-prometheus-example</artifactId>
     <version>1.0-SNAPSHOT</version>
+
+    <name>Javalin 5 ${artifactId}</name>
 
     <properties>
         <kotlin.version>1.7.0</kotlin.version>

--- a/javalin5/javalin-realtime-collaboration-example/pom.xml
+++ b/javalin5/javalin-realtime-collaboration-example/pom.xml
@@ -3,12 +3,12 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.javalin</groupId>
+    <groupId>io.javalin.samples.javalin5</groupId>
     <artifactId>javalin-realtime-collaboration-example</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>io.javalin javalin-realtime-collaboration-example</name>
+    <name>Javalin 5 ${artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin5/javalin-testing-example/pom.xml
+++ b/javalin5/javalin-testing-example/pom.xml
@@ -3,12 +3,12 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.javalin</groupId>
+    <groupId>io.javalin.samples.javalin5</groupId>
     <artifactId>javalin-testing-example</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>io.javalin javalin-testing-example</name>
+    <name>Javalin 5 ${artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin5/javalin-vuejs-example/pom.xml
+++ b/javalin5/javalin-vuejs-example/pom.xml
@@ -3,12 +3,12 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.javalin</groupId>
+    <groupId>io.javalin.samples.javalin5</groupId>
     <artifactId>javalin-vuejs-example</artifactId>
     <version>1.0</version>
     <packaging>jar</packaging>
 
-    <name>io.javalin javalin-vuejs-example</name>
+    <name>Javalin 5 ${artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin5/javalin-websocket-example/pom.xml
+++ b/javalin5/javalin-websocket-example/pom.xml
@@ -4,9 +4,11 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.javalin</groupId>
+    <groupId>io.javalin.samples.javalin5</groupId>
     <artifactId>javalin-websocket-example</artifactId>
     <version>1.0</version>
+
+    <name>Javalin 5 ${artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/javalin5/javalinstagram/pom.xml
+++ b/javalin5/javalinstagram/pom.xml
@@ -3,12 +3,12 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.javalin</groupId>
+    <groupId>io.javalin.samples.javalin5</groupId>
     <artifactId>javalinstagram</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>javalinstagram</name>
+    <name>Javalin 5 ${artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin5/javalinvue-example/javalinvue2-example/pom.xml
+++ b/javalin5/javalinvue-example/javalinvue2-example/pom.xml
@@ -3,12 +3,12 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.javalin</groupId>
+    <groupId>io.javalin.samples.javalin5</groupId>
     <artifactId>javalinvue2-example</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>io.javalin javalinvue-example</name>
+    <name>Javalin 5 ${artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin5/javalinvue-example/javalinvue3-example/pom.xml
+++ b/javalin5/javalinvue-example/javalinvue3-example/pom.xml
@@ -3,12 +3,12 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.javalin</groupId>
+    <groupId>io.javalin.samples.javalin5</groupId>
     <artifactId>javalinvue3-example</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>io.javalin javalinvue-example</name>
+    <name>Javalin 5 ${artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin5/pom.xml
+++ b/javalin5/pom.xml
@@ -7,6 +7,8 @@
     <version>1.0.0</version>
     <packaging>pom</packaging>
 
+    <name>Javalin 5 samples</name>
+
     <modules>
         <module>javalin-async-example</module>
         <module>javalin-auth-example</module>

--- a/pom.xml
+++ b/pom.xml
@@ -3,9 +3,11 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.javalin.samples</groupId>
-    <artifactId>javalin-samples-parent</artifactId>
+    <artifactId>javalin-samples-aggregator</artifactId>
     <version>1.0.0</version>
     <packaging>pom</packaging>
+
+    <name>Javalin samples</name>
 
     <modules>
         <module>javalin4</module>


### PR DESCRIPTION
I had quite some issues with duplicate coordinates while creating the aggregator poms. 

This PR unifies the groupId to  `io.javalin.samples.javalin4` / `io.javalin.samples.javalin5`.
Names are unified to `Javalin 4 ${artifactId}` / `Javalin 5 ${artifactId}` and the artifactId is the same as the containing folder.

