### PR TITLE
Fix all remaining examples

### DIFF
--- a/javalin4/javalin-async-example/pom.xml
+++ b/javalin4/javalin-async-example/pom.xml
@@ -65,6 +65,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>

--- a/javalin4/javalin-async-example/pom.xml
+++ b/javalin4/javalin-async-example/pom.xml
@@ -8,7 +8,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>Javalin 4 ${artifactId}</name>
+    <name>Javalin 4 ${project.artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin4/javalin-cors-example/pom.xml
+++ b/javalin4/javalin-cors-example/pom.xml
@@ -8,7 +8,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>Javalin 4 ${artifactId}</name>
+    <name>Javalin 4 ${project.artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin4/javalin-cors-example/pom.xml
+++ b/javalin4/javalin-cors-example/pom.xml
@@ -12,8 +12,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kotlin.version>1.3.21</kotlin.version>
-        <junit.version>4.12</junit.version>
+        <kotlin.version>1.5.32</kotlin.version>
+        <junit.version>4.13.2</junit.version>
     </properties>
 
     <dependencies>
@@ -25,12 +25,12 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20160810</version>
+            <version>20220924</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.30</version>
+            <version>1.7.36</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/javalin4/javalin-cors-example/src/main/kotlin/app/Main.kt
+++ b/javalin4/javalin-cors-example/src/main/kotlin/app/Main.kt
@@ -17,7 +17,7 @@ fun main(args: Array<String>) {
             put("contact", "admin@domain.com")
         }
         ctx.result(res.toString()).contentType("application/json")
-    }.start(80)
+    }.start(8080)
 
     Javalin.create {
         it.addStaticFiles("/public", Location.CLASSPATH)

--- a/javalin4/javalin-cors-example/src/main/resources/public/index.html
+++ b/javalin4/javalin-cors-example/src/main/resources/public/index.html
@@ -7,7 +7,7 @@
         <div id="output">fetching...</div>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/axios/0.18.0/axios.min.js"></script>
         <script>
-            axios.get('http://localhost:80').then(response => {
+            axios.get('http://localhost:8080').then(response => {
                 document.getElementById("output").innerHTML = JSON.stringify(response.data);
             });
         </script>

--- a/javalin4/javalin-email-example/pom.xml
+++ b/javalin4/javalin-email-example/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>javalin-email-example</artifactId>
     <version>1.0-SNAPSHOT</version>
 
-    <name>Javalin 4 ${artifactId}</name>
+    <name>Javalin 4 ${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/javalin4/javalin-heroku-example/pom.xml
+++ b/javalin4/javalin-heroku-example/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>javalin-heroku-example</artifactId>
     <version>1.0</version>
 
-    <name>Javalin 4 ${artifactId}</name>
+    <name>Javalin 4 ${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/javalin4/javalin-html-forms-example/pom.xml
+++ b/javalin4/javalin-html-forms-example/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>javalin-html-forms-example</artifactId>
     <version>1.0-SNAPSHOT</version>
 
-    <name>Javalin 4 ${artifactId}</name>
+    <name>Javalin 4 ${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/javalin4/javalin-jetty-sessions-example/pom.xml
+++ b/javalin4/javalin-jetty-sessions-example/pom.xml
@@ -8,7 +8,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>Javalin 4 ${artifactId}</name>
+    <name>Javalin 4 ${project.artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin4/javalin-jetty-sessions-example/pom.xml
+++ b/javalin4/javalin-jetty-sessions-example/pom.xml
@@ -66,6 +66,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
                 <configuration>
                     <source>8</source>
                     <target>8</target>

--- a/javalin4/javalin-kotlin-example/pom.xml
+++ b/javalin4/javalin-kotlin-example/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>javalin-kotlin-example</artifactId>
     <version>1.0-SNAPSHOT</version>
 
-    <name>Javalin 4 ${artifactId}</name>
+    <name>Javalin 4 ${project.artifactId}</name>
 
     <properties>
         <kotlin.version>1.5.20</kotlin.version>

--- a/javalin4/javalin-openapi-example/pom.xml
+++ b/javalin4/javalin-openapi-example/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>Javalin 4 ${artifactId}</name>
+    <name>Javalin 4 ${project.artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin4/javalin-openapi-example/pom.xml
+++ b/javalin4/javalin-openapi-example/pom.xml
@@ -13,9 +13,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kotlin.version>1.5.31</kotlin.version>
+        <kotlin.version>1.5.32</kotlin.version>
         <kotlin.code.style>official</kotlin.code.style>
-        <junit.version>4.12</junit.version>
+        <junit.version>4.13.2</junit.version>
     </properties>
 
     <dependencies>
@@ -34,31 +34,22 @@
             <artifactId>kotlin-reflect</artifactId>
             <version>${kotlin.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-common</artifactId>
-            <version>${kotlin.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib</artifactId>
-            <version>${kotlin.version}</version>
-        </dependency>
         <!-- okhttp/moshi is only required to consume the API, using the auto generated client -->
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>4.3.0</version>
+            <version>4.10.0</version>
         </dependency>
+        <!-- newer moshi version require a newer Kotlin version -->
         <dependency>
             <groupId>com.squareup.moshi</groupId>
             <artifactId>moshi-kotlin</artifactId>
-            <version>1.9.2</version>
+            <version>1.12.0</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.moshi</groupId>
             <artifactId>moshi-adapters</artifactId>
-            <version>1.9.2</version>
+            <version>1.12.0</version>
         </dependency>
     </dependencies>
 
@@ -89,6 +80,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
                 <configuration>
                     <source>8</source>
                     <target>8</target>
@@ -104,8 +96,8 @@
                             <goal>generate</goal>
                         </goals>
                         <configuration>
+                            <generatorName>kotlin</generatorName>
                             <inputSpec>${project.basedir}/src/main/resources/api.json</inputSpec>
-                            <language>kotlin</language>
                             <configOptions>
                                 <sourceFolder>src/gen/java/main</sourceFolder>
                             </configOptions>

--- a/javalin4/javalin-prometheus-example/pom.xml
+++ b/javalin4/javalin-prometheus-example/pom.xml
@@ -11,7 +11,7 @@
     <name>Javalin 4 ${project.artifactId}</name>
 
     <properties>
-        <kotlin.version>1.5.20</kotlin.version>
+        <kotlin.version>1.5.32</kotlin.version>
     </properties>
 
     <dependencies>
@@ -21,14 +21,20 @@
             <version>4.6.6</version>
         </dependency>
         <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.32</version>
+            <version>1.7.36</version>
         </dependency>
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient_httpserver</artifactId>
-            <version>0.11.0</version>
+            <version>0.16.0</version>
         </dependency>
         <dependency>
             <groupId>com.mashape.unirest</groupId>
@@ -72,6 +78,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
                 <executions>
                     <execution>
                         <id>compile</id>

--- a/javalin4/javalin-prometheus-example/pom.xml
+++ b/javalin4/javalin-prometheus-example/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>javalin-prometheus-example</artifactId>
     <version>1.0-SNAPSHOT</version>
 
-    <name>Javalin 4 ${artifactId}</name>
+    <name>Javalin 4 ${project.artifactId}</name>
 
     <properties>
         <kotlin.version>1.5.20</kotlin.version>

--- a/javalin4/javalin-prometheus-example/src/main/kotlin/Main.kt
+++ b/javalin4/javalin-prometheus-example/src/main/kotlin/Main.kt
@@ -1,5 +1,4 @@
 import com.mashape.unirest.http.Unirest
-import com.sun.media.jfxmedia.logging.Logger
 import io.javalin.Javalin
 import io.javalin.apibuilder.ApiBuilder.get
 import io.prometheus.client.exporter.HTTPServer

--- a/javalin4/javalin-realtime-collaboration-example/pom.xml
+++ b/javalin4/javalin-realtime-collaboration-example/pom.xml
@@ -8,7 +8,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>Javalin 4 ${artifactId}</name>
+    <name>Javalin 4 ${project.artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin4/javalin-realtime-collaboration-example/pom.xml
+++ b/javalin4/javalin-realtime-collaboration-example/pom.xml
@@ -23,9 +23,14 @@
             <version>4.6.6</version>
         </dependency>
         <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.32</version>
+            <version>1.7.36</version>
         </dependency>
     </dependencies>
 
@@ -56,6 +61,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>

--- a/javalin4/javalin-testing-example/pom.xml
+++ b/javalin4/javalin-testing-example/pom.xml
@@ -8,7 +8,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>Javalin 4 ${artifactId}</name>
+    <name>Javalin 4 ${project.artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin4/javalin-testing-example/pom.xml
+++ b/javalin4/javalin-testing-example/pom.xml
@@ -12,9 +12,14 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kotlin.version>1.5.20</kotlin.version>
+        <!--
+            We need to upgrade mockk for Java 19, but the newer versions seem to be incompatible with Maven when
+            combined with Kotlin 1.5.32. IntelliJ displays the mockk functions properly but Maven gets unresolved
+            reference errors.
+         -->
+        <kotlin.version>1.6.20</kotlin.version>
         <kotlin.code.style>official</kotlin.code.style>
-        <junit.version>4.13.1</junit.version>
+        <junit.version>4.13.2</junit.version>
     </properties>
 
     <dependencies>
@@ -24,9 +29,15 @@
             <version>4.6.6</version>
         </dependency>
         <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>4.9.0</version>
+            <version>4.10.0</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
@@ -34,6 +45,15 @@
             <version>${kotlin.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- required by mockk -->
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-reflect</artifactId>
+            <version>${kotlin.version}</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -43,20 +63,26 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.11.1</version>
+            <version>3.23.1</version>
             <scope>test</scope>
         </dependency>
         <!-- Unit -->
         <dependency>
             <groupId>io.mockk</groupId>
             <artifactId>mockk</artifactId>
-            <version>1.9.3</version>
+            <version>1.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.mockk</groupId>
+            <artifactId>mockk-jvm</artifactId>
+            <version>1.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.2.4</version>
+            <version>4.8.0</version>
             <scope>test</scope>
         </dependency>
         <!-- Functional -->
@@ -64,13 +90,13 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-chrome-driver</artifactId>
-            <version>3.141.59</version>
+            <version>4.5.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>4.4.3</version>
+            <version>5.3.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -86,14 +112,12 @@
                 <executions>
                     <execution>
                         <id>compile</id>
-                        <phase>compile</phase>
                         <goals>
                             <goal>compile</goal>
                         </goals>
                     </execution>
                     <execution>
                         <id>test-compile</id>
-                        <phase>test-compile</phase>
                         <goals>
                             <goal>test-compile</goal>
                         </goals>
@@ -103,6 +127,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
                 <configuration>
                     <source>8</source>
                     <target>8</target>

--- a/javalin4/javalin-testing-example/src/test/kotlin/io/javalin/example/kotlin/EndToEndTest.kt
+++ b/javalin4/javalin-testing-example/src/test/kotlin/io/javalin/example/kotlin/EndToEndTest.kt
@@ -1,7 +1,7 @@
 package io.javalin.example.kotlin
 
 import io.github.bonigarcia.wdm.WebDriverManager
-import io.javalin.testtools.TestUtil
+import io.javalin.testtools.JavalinTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.openqa.selenium.WebDriver
@@ -13,7 +13,7 @@ class EndToEndTest {
     private val app = Application("someDependency").app // inject any dependencies you might have
 
     @Test
-    fun `UI contains correct heading`() = TestUtil.test(app) { server, client ->
+    fun `UI contains correct heading`() = JavalinTest.test(app) { server, client ->
         WebDriverManager.chromedriver().setup()
         val driver: WebDriver = ChromeDriver(ChromeOptions().apply {
             addArguments("--headless")

--- a/javalin4/javalin-testing-example/src/test/kotlin/io/javalin/example/kotlin/FunctionalTest.kt
+++ b/javalin4/javalin-testing-example/src/test/kotlin/io/javalin/example/kotlin/FunctionalTest.kt
@@ -1,7 +1,7 @@
 package io.javalin.example.kotlin
 
 import io.javalin.plugin.json.JavalinJackson
-import io.javalin.testtools.TestUtil
+import io.javalin.testtools.JavalinTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -11,7 +11,7 @@ class FunctionalTest {
     private val usersJson = JavalinJackson().toJsonString(UserController.users)
 
     @Test
-    fun `GET to fetch users returns list of users`() = TestUtil.test(app) { server, client ->
+    fun `GET to fetch users returns list of users`() = JavalinTest.test(app) { server, client ->
         assertThat(client.get("/users").code).isEqualTo(200)
         assertThat(client.get("/users").body?.string()).isEqualTo(usersJson)
     }

--- a/javalin4/javalin-vuejs-example/pom.xml
+++ b/javalin4/javalin-vuejs-example/pom.xml
@@ -8,7 +8,7 @@
     <version>1.0</version>
     <packaging>jar</packaging>
 
-    <name>Javalin 4 ${artifactId}</name>
+    <name>Javalin 4 ${project.artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin4/javalin-website-example/pom.xml
+++ b/javalin4/javalin-website-example/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>javalin-website-example</artifactId>
     <version>1.0</version>
 
-    <name>Javalin 4 ${artifactId}</name>
+    <name>Javalin 4 ${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/javalin4/javalin-websocket-example/pom.xml
+++ b/javalin4/javalin-websocket-example/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>javalin-websocket-example</artifactId>
     <version>1.0</version>
 
-    <name>Javalin 4 ${artifactId}</name>
+    <name>Javalin 4 ${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/javalin4/javalinstagram/pom.xml
+++ b/javalin4/javalinstagram/pom.xml
@@ -8,7 +8,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>Javalin 4 ${artifactId}</name>
+    <name>Javalin 4 ${project.artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin4/javalinvue-example/javalinvue2-example/pom.xml
+++ b/javalin4/javalinvue-example/javalinvue2-example/pom.xml
@@ -8,7 +8,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>Javalin 4 ${artifactId}</name>
+    <name>Javalin 4 ${project.artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin4/javalinvue-example/javalinvue3-example/pom.xml
+++ b/javalin4/javalinvue-example/javalinvue3-example/pom.xml
@@ -8,7 +8,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>Javalin 4 ${artifactId}</name>
+    <name>Javalin 4 ${project.artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin4/pom.xml
+++ b/javalin4/pom.xml
@@ -11,7 +11,7 @@
 
     <modules>
         <module>javalin-async-example</module>
-        <!--<module>javalin-cors-example</module> checked-->
+        <module>javalin-cors-example</module>
         <module>javalin-email-example</module>
         <module>javalin-heroku-example</module>
         <module>javalin-html-forms-example</module>

--- a/javalin4/pom.xml
+++ b/javalin4/pom.xml
@@ -18,7 +18,7 @@
         <module>javalin-jetty-sessions-example</module>
         <module>javalin-kotlin-example</module>
         <!--<module>javalin-openapi-example</module> checked -->
-        <!--<module>javalin-prometheus-example</module> checked -->
+        <module>javalin-prometheus-example</module>
         <module>javalin-realtime-collaboration-example</module>
         <!-- flaky due to Byte buddy version -->
         <!--<module>javalin-testing-example</module>-->

--- a/javalin4/pom.xml
+++ b/javalin4/pom.xml
@@ -17,7 +17,7 @@
         <module>javalin-html-forms-example</module>
         <module>javalin-jetty-sessions-example</module>
         <module>javalin-kotlin-example</module>
-        <!--<module>javalin-openapi-example</module> checked -->
+        <module>javalin-openapi-example</module>
         <module>javalin-prometheus-example</module>
         <module>javalin-realtime-collaboration-example</module>
         <!-- flaky due to Byte buddy version -->

--- a/javalin4/pom.xml
+++ b/javalin4/pom.xml
@@ -20,8 +20,7 @@
         <module>javalin-openapi-example</module>
         <module>javalin-prometheus-example</module>
         <module>javalin-realtime-collaboration-example</module>
-        <!-- flaky due to Byte buddy version -->
-        <!--<module>javalin-testing-example</module>-->
+        <module>javalin-testing-example</module>
         <module>javalin-vuejs-example</module>
         <module>javalin-website-example</module>
         <module>javalin-websocket-example</module>

--- a/javalin5/javalin-async-example/pom.xml
+++ b/javalin5/javalin-async-example/pom.xml
@@ -8,7 +8,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>Javalin 5 ${artifactId}</name>
+    <name>Javalin 5 ${project.artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin5/javalin-async-example/pom.xml
+++ b/javalin5/javalin-async-example/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kotlin.version>1.7.10</kotlin.version>
+        <kotlin.version>1.7.20</kotlin.version>
         <kotlin.code.style>official</kotlin.code.style>
         <kotlin.compiler.jvmTarget>11</kotlin.compiler.jvmTarget>
     </properties>
@@ -43,6 +43,12 @@
                         <goals>
                             <goal>compile</goal>
                         </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/main/java</sourceDir>
+                            </sourceDirs>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>test-compile</id>
@@ -50,16 +56,49 @@
                         <goals>
                             <goal>test-compile</goal>
                         </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/test/java</sourceDir>
+                            </sourceDirs>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
                 <configuration>
                     <source>11</source>
                     <target>11</target>
                 </configuration>
+                <executions>
+                    <!-- Replacing default-compile as it is treated specially by maven -->
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <!-- Replacing default-testCompile as it is treated specially by maven -->
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>java-compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>java-test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/javalin5/javalin-auth-example/pom.xml
+++ b/javalin5/javalin-auth-example/pom.xml
@@ -8,7 +8,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>Javalin 5 ${artifactId}</name>
+    <name>Javalin 5 ${project.artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin5/javalin-cors-example/pom.xml
+++ b/javalin5/javalin-cors-example/pom.xml
@@ -8,7 +8,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>Javalin 5 ${artifactId}</name>
+    <name>Javalin 5 ${project.artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin5/javalin-email-example/pom.xml
+++ b/javalin5/javalin-email-example/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>javalin-email-example</artifactId>
     <version>1.0-SNAPSHOT</version>
 
-    <name>Javalin 5 ${artifactId}</name>
+    <name>Javalin 5 ${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/javalin5/javalin-heroku-example/pom.xml
+++ b/javalin5/javalin-heroku-example/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>javalin-heroku-example</artifactId>
     <version>1.0</version>
 
-    <name>Javalin 5 ${artifactId}</name>
+    <name>Javalin 5 ${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/javalin5/javalin-html-forms-example/pom.xml
+++ b/javalin5/javalin-html-forms-example/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>javalin-html-forms-example</artifactId>
     <version>1.0-SNAPSHOT</version>
 
-    <name>Javalin 5 ${artifactId}</name>
+    <name>Javalin 5 ${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/javalin5/javalin-http2-example/pom.xml
+++ b/javalin5/javalin-http2-example/pom.xml
@@ -8,7 +8,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>Javalin 5 ${artifactId}</name>
+    <name>Javalin 5 ${project.artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin5/javalin-http2-example/pom.xml
+++ b/javalin5/javalin-http2-example/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kotlin.version>1.7.10</kotlin.version>
+        <kotlin.version>1.7.20</kotlin.version>
         <kotlin.code.style>official</kotlin.code.style>
         <junit.version>4.13.1</junit.version>
     </properties>
@@ -55,9 +55,6 @@
     </dependencies>
 
     <build>
-        <sourceDirectory>src/main/kotlin</sourceDirectory>
-        <testSourceDirectory>src/test/kotlin</testSourceDirectory>
-
         <plugins>
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
@@ -66,27 +63,64 @@
                 <executions>
                     <execution>
                         <id>compile</id>
-                        <phase>compile</phase>
                         <goals>
                             <goal>compile</goal>
                         </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/main/java</sourceDir>
+                            </sourceDirs>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>test-compile</id>
-                        <phase>test-compile</phase>
                         <goals>
                             <goal>test-compile</goal>
                         </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/test/java</sourceDir>
+                            </sourceDirs>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
+                <executions>
+                    <!-- Replacing default-compile as it is treated specially by maven -->
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <!-- Replacing default-testCompile as it is treated specially by maven -->
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>java-compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>java-test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/javalin5/javalin-jetty-sessions-example/pom.xml
+++ b/javalin5/javalin-jetty-sessions-example/pom.xml
@@ -8,7 +8,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>Javalin 5 ${artifactId}</name>
+    <name>Javalin 5 ${project.artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin5/javalin-jetty-sessions-example/pom.xml
+++ b/javalin5/javalin-jetty-sessions-example/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kotlin.version>1.7.0</kotlin.version>
+        <kotlin.version>1.7.20</kotlin.version>
     </properties>
 
     <dependencies>
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-nosql</artifactId>
-            <version>11.0.11</version>
+            <version>11.0.12</version>
         </dependency>
     </dependencies>
 
@@ -38,27 +38,62 @@
                 <executions>
                     <execution>
                         <id>compile</id>
-                        <phase>compile</phase>
                         <goals>
                             <goal>compile</goal>
                         </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/main/java</sourceDir>
+                            </sourceDirs>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>test-compile</id>
-                        <phase>test-compile</phase>
-                        <goals>
-                            <goal>test-compile</goal>
-                        </goals>
+                        <goals> <goal>test-compile</goal> </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/test/java</sourceDir>
+                            </sourceDirs>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
+                <executions>
+                    <!-- Replacing default-compile as it is treated specially by maven -->
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <!-- Replacing default-testCompile as it is treated specially by maven -->
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>java-compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>java-test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/javalin5/javalin-kotlin-example/pom.xml
+++ b/javalin5/javalin-kotlin-example/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>javalin-kotlin-example</artifactId>
     <version>1.0-SNAPSHOT</version>
 
-    <name>Javalin 5 ${artifactId}</name>
+    <name>Javalin 5 ${project.artifactId}</name>
 
     <properties>
         <kotlin.version>1.7.0</kotlin.version>

--- a/javalin5/javalin-modern-java-example/pom.xml
+++ b/javalin5/javalin-modern-java-example/pom.xml
@@ -7,7 +7,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>Javalin 5 ${artifactId}</name>
+    <name>Javalin 5 ${project.artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin5/javalin-modern-java-example/pom.xml
+++ b/javalin5/javalin-modern-java-example/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>io.javalin</groupId>
             <artifactId>javalin-rendering</artifactId>
-            <version>5.0.0</version>
+            <version>5.0.1</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -37,6 +37,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
                 <configuration>
                     <source>18</source>
                     <target>18</target>

--- a/javalin5/javalin-openapi-example/pom.xml
+++ b/javalin5/javalin-openapi-example/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>Javalin 5 ${artifactId}</name>
+    <name>Javalin 5 ${project.artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin5/javalin-prometheus-example/pom.xml
+++ b/javalin5/javalin-prometheus-example/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>javalin-prometheus-example</artifactId>
     <version>1.0-SNAPSHOT</version>
 
-    <name>Javalin 5 ${artifactId}</name>
+    <name>Javalin 5 ${project.artifactId}</name>
 
     <properties>
         <kotlin.version>1.7.0</kotlin.version>

--- a/javalin5/javalin-prometheus-example/pom.xml
+++ b/javalin5/javalin-prometheus-example/pom.xml
@@ -11,7 +11,7 @@
     <name>Javalin 5 ${project.artifactId}</name>
 
     <properties>
-        <kotlin.version>1.7.0</kotlin.version>
+        <kotlin.version>1.7.20</kotlin.version>
     </properties>
 
     <dependencies>
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>com.konghq</groupId>
             <artifactId>unirest-java</artifactId>
-            <version>3.13.10</version>
+            <version>3.13.11</version>
         </dependency>
     </dependencies>
 
@@ -67,26 +67,37 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
                 <executions>
+                    <!-- Replacing default-compile as it is treated specially by maven -->
                     <execution>
-                        <id>compile</id>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <!-- Replacing default-testCompile as it is treated specially by maven -->
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>java-compile</id>
                         <phase>compile</phase>
                         <goals>
                             <goal>compile</goal>
                         </goals>
                     </execution>
                     <execution>
-                        <id>testCompile</id>
+                        <id>java-test-compile</id>
                         <phase>test-compile</phase>
                         <goals>
                             <goal>testCompile</goal>
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <source>11</source>
-                    <target>11</target>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/javalin5/javalin-realtime-collaboration-example/pom.xml
+++ b/javalin5/javalin-realtime-collaboration-example/pom.xml
@@ -8,7 +8,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>Javalin 5 ${artifactId}</name>
+    <name>Javalin 5 ${project.artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin5/javalin-realtime-collaboration-example/pom.xml
+++ b/javalin5/javalin-realtime-collaboration-example/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kotlin.version>1.7.0</kotlin.version>
+        <kotlin.version>1.7.20</kotlin.version>
     </properties>
 
     <dependencies>
@@ -21,39 +21,81 @@
             <artifactId>javalin-bundle</artifactId>
             <version>5.0.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
-        <sourceDirectory>src/main/kotlin</sourceDirectory>
         <plugins>
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <version>${kotlin.version}</version>
+                <configuration>
+                    <jvmTarget>11</jvmTarget>
+                </configuration>
                 <executions>
                     <execution>
                         <id>compile</id>
-                        <phase>process-sources</phase>
                         <goals>
                             <goal>compile</goal>
                         </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/main/java</sourceDir>
+                            </sourceDirs>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>test-compile</id>
-                        <phase>test-compile</phase>
-                        <goals>
-                            <goal>test-compile</goal>
-                        </goals>
+                        <goals> <goal>test-compile</goal> </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/test/java</sourceDir>
+                            </sourceDirs>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
                 <configuration>
                     <source>11</source>
                     <target>11</target>
                 </configuration>
+                <executions>
+                    <!-- Replacing default-compile as it is treated specially by maven -->
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <!-- Replacing default-testCompile as it is treated specially by maven -->
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>java-compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>java-test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/javalin5/javalin-testing-example/pom.xml
+++ b/javalin5/javalin-testing-example/pom.xml
@@ -8,7 +8,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>Javalin 5 ${artifactId}</name>
+    <name>Javalin 5 ${project.artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin5/javalin-testing-example/pom.xml
+++ b/javalin5/javalin-testing-example/pom.xml
@@ -12,9 +12,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kotlin.version>1.7.0</kotlin.version>
+        <kotlin.version>1.7.20</kotlin.version>
         <kotlin.code.style>official</kotlin.code.style>
-        <junit.version>4.13.1</junit.version>
+        <junit.version>4.13.2</junit.version>
     </properties>
 
     <dependencies>
@@ -49,8 +49,8 @@
         <!-- Unit -->
         <dependency>
             <groupId>io.mockk</groupId>
-            <artifactId>mockk</artifactId>
-            <version>1.12.5</version>
+            <artifactId>mockk-jvm</artifactId>
+            <version>1.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-chrome-driver</artifactId>
-            <version>4.3.0</version>
+            <version>4.5.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -76,37 +76,73 @@
     </dependencies>
 
     <build>
-        <sourceDirectory>src/main/kotlin</sourceDirectory>
-        <testSourceDirectory>src/test/kotlin</testSourceDirectory>
         <plugins>
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <version>${kotlin.version}</version>
+                <configuration>
+                    <jvmTarget>11</jvmTarget>
+                </configuration>
                 <executions>
                     <execution>
                         <id>compile</id>
-                        <phase>compile</phase>
                         <goals>
                             <goal>compile</goal>
                         </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/main/java</sourceDir>
+                            </sourceDirs>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>test-compile</id>
-                        <phase>test-compile</phase>
-                        <goals>
-                            <goal>test-compile</goal>
-                        </goals>
+                        <goals> <goal>test-compile</goal> </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+                                <sourceDir>${project.basedir}/src/test/java</sourceDir>
+                            </sourceDirs>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
                 <configuration>
                     <source>11</source>
                     <target>11</target>
                 </configuration>
+                <executions>
+                    <!-- Replacing default-compile as it is treated specially by maven -->
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <!-- Replacing default-testCompile as it is treated specially by maven -->
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>java-compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>java-test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/javalin5/javalin-testing-example/pom.xml
+++ b/javalin5/javalin-testing-example/pom.xml
@@ -25,6 +25,11 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-test-junit</artifactId>
             <version>${kotlin.version}</version>
             <scope>test</scope>

--- a/javalin5/javalin-testing-example/src/test/java/io/javalin/example/java/FunctionalTest.java
+++ b/javalin5/javalin-testing-example/src/test/java/io/javalin/example/java/FunctionalTest.java
@@ -1,7 +1,7 @@
 package io.javalin.example.java;
 
 import io.javalin.Javalin;
-import io.javalin.plugin.json.JavalinJackson;
+import io.javalin.json.JavalinJackson
 import io.javalin.testtools.JavalinTest;
 import org.junit.Test;
 
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class FunctionalTest {
 
     Javalin app = new JavalinTestingExampleApp("someDependency").javalinApp(); // inject any dependencies you might have
-    private final String usersJson = new JavalinJackson().toJsonString(UserController.users);
+    private final String usersJson = new JavalinJackson().toJsonString(UserController.users, List::class);
 
     @Test
     public void GET_to_fetch_users_returns_list_of_users() {

--- a/javalin5/javalin-testing-example/src/test/java/io/javalin/example/java/FunctionalTest.java
+++ b/javalin5/javalin-testing-example/src/test/java/io/javalin/example/java/FunctionalTest.java
@@ -1,16 +1,18 @@
 package io.javalin.example.java;
 
 import io.javalin.Javalin;
-import io.javalin.json.JavalinJackson
+import io.javalin.json.JavalinJackson;
 import io.javalin.testtools.JavalinTest;
 import org.junit.Test;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class FunctionalTest {
 
     Javalin app = new JavalinTestingExampleApp("someDependency").javalinApp(); // inject any dependencies you might have
-    private final String usersJson = new JavalinJackson().toJsonString(UserController.users, List::class);
+    private final String usersJson = new JavalinJackson().toJsonString(UserController.users, List.class);
 
     @Test
     public void GET_to_fetch_users_returns_list_of_users() {

--- a/javalin5/javalin-testing-example/src/test/kotlin/io/javalin/example/kotlin/FunctionalTest.kt
+++ b/javalin5/javalin-testing-example/src/test/kotlin/io/javalin/example/kotlin/FunctionalTest.kt
@@ -1,6 +1,6 @@
 package io.javalin.example.kotlin
 
-import io.javalin.plugin.json.JavalinJackson
+import io.javalin.json.JavalinJackson
 import io.javalin.testtools.JavalinTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -8,7 +8,7 @@ import org.junit.Test
 class FunctionalTest {
 
     private val app = JavalinTestingExampleApp("someDependency").app // inject any dependencies you might have
-    private val usersJson = JavalinJackson().toJsonString(UserController.users)
+    private val usersJson = JavalinJackson().toJsonString(UserController.users, List::class.java)
 
     @Test
     fun `GET to fetch users returns list of users`() = JavalinTest.test(app) { server, client ->

--- a/javalin5/javalin-vuejs-example/pom.xml
+++ b/javalin5/javalin-vuejs-example/pom.xml
@@ -8,7 +8,7 @@
     <version>1.0</version>
     <packaging>jar</packaging>
 
-    <name>Javalin 5 ${artifactId}</name>
+    <name>Javalin 5 ${project.artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin5/javalin-websocket-example/pom.xml
+++ b/javalin5/javalin-websocket-example/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>javalin-websocket-example</artifactId>
     <version>1.0</version>
 
-    <name>Javalin 5 ${artifactId}</name>
+    <name>Javalin 5 ${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/javalin5/javalinstagram/pom.xml
+++ b/javalin5/javalinstagram/pom.xml
@@ -8,7 +8,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>Javalin 5 ${artifactId}</name>
+    <name>Javalin 5 ${project.artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin5/javalinstagram/pom.xml
+++ b/javalin5/javalinstagram/pom.xml
@@ -12,8 +12,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kotlin.version>1.7.0</kotlin.version>
-        <kotlin.compiler.jvmTarget>11</kotlin.compiler.jvmTarget>
+        <kotlin.version>1.7.20</kotlin.version>
     </properties>
 
     <dependencies>
@@ -23,6 +22,12 @@
             <version>5.0.1</version>
         </dependency>
         <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.nixxcode.jvmbrotli</groupId>
             <artifactId>jvmbrotli</artifactId>
             <version>0.2.0</version>
@@ -30,7 +35,7 @@
         <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
-            <version>3.30.1</version>
+            <version>3.39.3.0</version>
         </dependency>
         <dependency>
             <groupId>net.coobird</groupId>
@@ -45,7 +50,7 @@
         <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-core</artifactId>
-            <version>3.30.0</version>
+            <version>3.33.0</version>
         </dependency>
         <!-- WEBJARS -->
         <dependency>
@@ -77,17 +82,19 @@
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <version>${kotlin.version}</version>
+                <configuration>
+                    <jvmTarget>11</jvmTarget>
+                </configuration>
                 <executions>
                     <execution>
                         <id>compile</id>
-                        <phase>compile</phase>
                         <goals>
                             <goal>compile</goal>
                         </goals>
                     </execution>
+
                     <execution>
                         <id>test-compile</id>
-                        <phase>test-compile</phase>
                         <goals>
                             <goal>test-compile</goal>
                         </goals>
@@ -119,6 +126,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
                 <configuration>
                     <source>11</source>
                     <target>11</target>

--- a/javalin5/javalinvue-example/javalinvue2-example/pom.xml
+++ b/javalin5/javalinvue-example/javalinvue2-example/pom.xml
@@ -8,7 +8,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>Javalin 5 ${artifactId}</name>
+    <name>Javalin 5 ${project.artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin5/javalinvue-example/javalinvue3-example/pom.xml
+++ b/javalin5/javalinvue-example/javalinvue3-example/pom.xml
@@ -8,7 +8,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>Javalin 5 ${artifactId}</name>
+    <name>Javalin 5 ${project.artifactId}</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javalin5/pom.xml
+++ b/javalin5/pom.xml
@@ -19,7 +19,6 @@
         <module>javalin-http2-example</module>
         <module>javalin-jetty-sessions-example</module>
         <module>javalin-kotlin-example</module>
-        <!--<module>javalin-modern-java-example</module>-->
         <module>javalin-openapi-example</module>
         <module>javalin-prometheus-example</module>
         <module>javalin-realtime-collaboration-example</module>
@@ -30,4 +29,16 @@
         <module>javalinvue-example/javalinvue2-example</module>
         <module>javalinvue-example/javalinvue3-example</module>
     </modules>
+
+    <profiles>
+        <profile>
+            <id>modern-java</id>
+            <activation>
+                <jdk>[19,)</jdk>
+            </activation>
+            <modules>
+                <module>javalin-modern-java-example</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>

--- a/javalin5/pom.xml
+++ b/javalin5/pom.xml
@@ -22,7 +22,7 @@
         <module>javalin-openapi-example</module>
         <module>javalin-prometheus-example</module>
         <module>javalin-realtime-collaboration-example</module>
-        <!--<module>javalin-testing-example</module>-->
+        <module>javalin-testing-example</module>
         <module>javalin-vuejs-example</module>
         <module>javalin-websocket-example</module>
         <module>javalinstagram</module>


### PR DESCRIPTION
This PR fixes all examples which have been disabled until now. 

My goal was to stay with the released Kotlin minor version for each Javalin release. 
Due to changes in mockk related to Java 19 I had to abandon that plan for the Javalin 4 testing example. 
Some bug from the combination of Java 19 + Kotlin 1.5.32 + MockK 1.13.2 and Maven leads to not found errors for the mockk functions only when compiling with Maven. So I had to switch to Kotlin 1.6 for that example only.

I also removed all the maven warnings related to an unstable build, such as not using `${project.artifactId}` and not having a version specified for the maven-compiler-plugin.

Last but not least: The modern-java example is also enabled for JDK 19 and above :)