### PR TITLE
Fix javalin-websocket-example link

### DIFF
--- a/javalin4/javalin-websocket-example/README.md
+++ b/javalin4/javalin-websocket-example/README.md
@@ -1,5 +1,5 @@
 # javalin-websocket-example
 
-## source code for tutorial at [https://javalin.io/tutorials/websocket-example-kotlin](https://javalin.io/tutorials/websocket-example-kotlin) 
+## source code for tutorial at [https://javalin.io/tutorials/websocket-example](https://javalin.io/tutorials/websocket-example) 
 
 ### contains both kotlin and java source


### PR DESCRIPTION
The working link is: https://javalin.io/tutorials/websocket-example